### PR TITLE
Fix sms apps crashing without permissions

### DIFF
--- a/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
+++ b/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
@@ -2,6 +2,8 @@ package com.tkporter.sendsms;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.os.Build;
 import android.provider.Telephony;
 import android.net.Uri;
@@ -88,6 +90,12 @@ public class SendSMSModule extends ReactContextBaseJavaModule implements Activit
             if (attachment != null) {
                 Uri attachmentUrl = Uri.parse(attachment.getString("url"));
                 sendIntent.putExtra(Intent.EXTRA_STREAM, attachmentUrl);
+                
+                final PackageManager packageManager = getReactApplicationContext().getPackageManager();
+                for (ResolveInfo info : packageManager.queryIntentActivities(sendIntent, PackageManager.GET_RESOLVED_FILTER)) {
+                    final String packageName = info.activityInfo.packageName;
+                    getReactApplicationContext().grantUriPermission(packageName, attachmentUrl, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                }
 
                 String type = attachment.getString("androidType");
                 sendIntent.setType(type);


### PR DESCRIPTION
This code goes through all apps that correspond to given intent and gives them read access to attachment.

Without this error will pop up on many devices
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.google.android.apps.messaging, PID: 26367
    java.lang.SecurityException: UID 10120 does not have permission to content://com.xx.provider/external_files/Download/photo-736230.jpeg
```